### PR TITLE
Access token update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.php
+index.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 config.php
-index.php

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Tested on PHP 5.4
 
 Obtain a user key by enabling the API at:
 
-  https://go.trackvia.com/#/my-info
-
-Note, the API is only available for Enterprise level accounts
+  https://go.trackvia.com/#/account (Click API Access)
 
 ## Usage
 
@@ -24,6 +22,22 @@ First instantiate a TrackVia API object
 require_once 'lib/Api.php';
 use Trackvia\Api;
 $api = new Api("userName", "password", "12345abc");
+```
+
+There are two ways to authorize the API to access information in your account:
+
+1. With API User Auth Token (recommended):
+```PHP
+$api = new Api("myApiKey", "myAccessToken");
+// Successfully authenticated..
+// Make additional requests
+```
+2. With username and password:
+```PHP
+$api = new Api("myApiKey");
+$api->login("username", "password");
+// Successfully authenticated..
+// Make additional requests
 ```
 
 Then make calls against the api, list views:

--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -54,12 +54,20 @@ class Authentication extends EventDispatcher
     /**
      * @param TrackviaRequst $request
      */
-    public function __construct(Request $request, $user, $password, $baseUrl)
+    public function __construct(Request $request, $user, $password, $accessToken, $baseUrl)
     {
         $this->request = $request;
 
         $this->clientId     = 'TrackViaAPI';
-        $this->setUserCreds($user, $password);
+
+        if ($accessToken) {
+            $this->setTokenData(["value" => $accessToken]);
+        }
+
+        if ($user && $password) {
+            $this->setUserCreds($user, $password);
+        }
+
         $this->baseUrl = $baseUrl;
         
     }
@@ -195,7 +203,7 @@ class Authentication extends EventDispatcher
      */
     public function isAccessTokenExpired()
     {
-        if (!isset($this->tokenData['expires_at']) || $this->tokenData['expires_at'] <= time()) {
+        if (isset($this->tokenData['expires_at']) && $this->tokenData['expires_at'] <= time()) {
             echo "Expired access token\n";
             return true;
         }


### PR DESCRIPTION
Updated PHP SDK to be instantiated with API Key and accessToken for M2M Auth. (It previously required username and password).

Also created the option for the SDK to be instantiated with only an API Key, and then have person use login method with username / password, so accessToken is not required.

Updated README to reflect these changes.

Tested both the accessToken and username/password paths on production and QA2 environments.